### PR TITLE
Adding default test case for GenerateDocumentationTestCase

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -126,3 +126,21 @@ class GenerateDocumentationTestCase(unittest.TestCase):
                                  )
 
         self.assertEqual(documentation, expected_documentation)
+
+    def test_default(self):
+        confirm = """
+        "section":
+            "option":
+                "default": "1"
+        """.strip()
+        
+        schema = yaml.load(StringIO(confirm))
+        documentation = generator.generate_documentation(schema)
+
+        expected_documentation = (
+                                  "Configuration documentation\n---------------------------\n\n"
+                                  "section\n=======\n\n"
+                                  "option\n======\nThe default value is 1.\n"
+                                 )
+                                 
+        self.assertEqual(documentation, expected_documentation)


### PR DESCRIPTION
There is likely something that can be done regarding the repeating information in the expected documentation variables. (define variables in a setUp function?)
