### PR TITLE
Interpolation compatible + extension case insensitive

### DIFF
--- a/confirm/utils.py
+++ b/confirm/utils.py
@@ -1,8 +1,8 @@
 from difflib import get_close_matches
 try:
-    from ConfigParser import SafeConfigParser
+    from ConfigParser import RawConfigParser
 except ImportError:
-    from configparser import ConfigParser as SafeConfigParser
+    from configparser import ConfigParser
 try:
     from StringIO import StringIO
 except ImportError:
@@ -43,10 +43,10 @@ def load_config_file(config_file_path, config_file):
     :returns: Dictionary representation of the configuration file.
     """
 
-    if config_file_path.endswith(".yaml"):
+    if config_file_path.lower().endswith(".yaml"):
         return yaml.load(config_file)
 
-    if any(config_file_path.endswith(extension) for extension in INI_FILE_EXTENSIONS):
+    if any(config_file_path.lower().endswith(extension) for extension in INI_FILE_EXTENSIONS):
         return load_config_from_ini_file(config_file)
 
     # At this point we have to guess the format of the configuration file.
@@ -65,7 +65,12 @@ def load_config_file(config_file_path, config_file):
 
 def load_config_from_ini_file(ini_file_content):
     ini_file_buffer = StringIO(ini_file_content)
-    config_parser = SafeConfigParser()
+
+    try:
+        config_parser = ConfigParser(interpolation=None)
+    except NameError:
+        config_parser = RawConfigParser()
+
     config_parser.readfp(ini_file_buffer)
     return config_parser_to_dict(config_parser)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,3 +37,46 @@ class LoadConfigFileTestCase(unittest.TestCase):
         loaded_config = utils.load_config_file(config_file_path, config_file)
 
         self.assertIn('section', loaded_config)
+
+    def test_extension_case_insensitive(self):
+        config_file = """
+        section:
+          option=value
+        """
+        config_file_path = 'schema.yaml'
+        loaded_config = utils.load_config_file(config_file_path, config_file)
+
+        self.assertIn('section', loaded_config)
+
+        config_file_path = 'schema.YAML'
+        loaded_config = utils.load_config_file(config_file_path, config_file)
+
+        self.assertIn('section', loaded_config)
+
+        config_file = """[section]\noption=value"""
+        config_file_path = 'schema.CONF'
+        loaded_config = utils.load_config_file(config_file_path, config_file)
+
+        self.assertIn('section', loaded_config)
+
+        config_file_path = 'schema.conf'
+        loaded_config = utils.load_config_file(config_file_path, config_file)
+
+        self.assertIn('section', loaded_config)
+
+    def test_ini_interpolation_compatible(self):
+        config_file = """[section]\noption=%(value)s %()s %s"""
+        config_file_path = 'schema.ini'
+        loaded_config = utils.load_config_file(config_file_path, config_file)
+
+        self.assertIn('section', loaded_config)
+
+    def test_yaml_interpolation_compatible(self):
+        config_file = """
+        section:
+          option=%(value)s %()s %s
+        """
+        config_file_path = 'schema.yaml'
+        loaded_config = utils.load_config_file(config_file_path, config_file)
+
+        self.assertIn('section', loaded_config)


### PR DESCRIPTION
I'm making these changes so that a configuration file with interpolation could still be validated.
For instance we have the following configuration : 

```
[formatter_form1]
format=%(asctime)s %(levelname)s [%(filename)s:%(lineno)d] %(message)s
datefmt=
```

Confirm will raise an interpolation syntax error and the changes made fix that.

The last change made is for `file.CONF` to not raise the exception `"Could not load configuration file!"` and to behave exactly like `file.conf`.

@Ronan- Could you please review the following ?
